### PR TITLE
Fixed text color when hovering in light mode

### DIFF
--- a/packages/frontendmu-nuxt/pages/team.vue
+++ b/packages/frontendmu-nuxt/pages/team.vue
@@ -64,7 +64,7 @@
             </div>
           </NuxtLink>
           <a v-if="person?.github_account" :href="`https://github.com/${person?.github_account}`" target="_blank"
-            class="flex justify-center gap-2 items-center dark:text-verse-400 text-verse-600 hover:text-verse-100 hover:dark:text-verse-100">
+            class="flex justify-center gap-2 items-center dark:text-verse-400 text-verse-600 hover:text-verse-400 hover:dark:text-verse-100">
             <Icon name="carbon:logo-github" class="w-4 h-4" />
             <p class="font-heading ">
               {{ person?.github_account }}


### PR DESCRIPTION
**Changes:**
- `hover:text-verse-`**100** to `hover:text-verse-`**400**.

**How to test**

- Pull changes locally
- Run the app on light mode
- Navigate to `http://localhost:3000/team` to the `Speakers` section
- Hover on the github account below the speaker's name


Closes #149 