### PR TITLE
Make hover (light mode) link text visible

### DIFF
--- a/packages/frontendmu-nuxt/pages/team.vue
+++ b/packages/frontendmu-nuxt/pages/team.vue
@@ -64,7 +64,7 @@
             </div>
           </NuxtLink>
           <a v-if="person?.github_account" :href="`https://github.com/${person?.github_account}`" target="_blank"
-            class="flex justify-center gap-2 items-center dark:text-verse-400 text-verse-600 hover:text-verse-100 hover:dark:text-verse-100">
+            class="flex justify-center gap-2 items-center dark:text-verse-400 text-verse-600 hover:text-verse-900 hover:dark:text-verse-100">
             <Icon name="carbon:logo-github" class="w-4 h-4" />
             <p class="font-heading ">
               {{ person?.github_account }}


### PR DESCRIPTION
The hover text colour is currently the same as the background colour; which means the text disappears on hover in light mode. I don't know what the best hover colour is, but this is where it needs to change in code. Feel free to close and implement in another PR.