### PR TITLE
#158 Bug: Attempt to fix contributors not being updated on the website

### DIFF
--- a/packages/frontendmu-data/scripts/update-contributors.js
+++ b/packages/frontendmu-data/scripts/update-contributors.js
@@ -2,9 +2,8 @@ import fs from "fs";
 import { execSync } from "child_process";
 
 const owner = "Front-End-Coders-Mauritius";
-const repo = "frontendmu.mu";
+const repo = "frontend.mu";
 const branch = "main"; // Replace with the default branch of your repository
-
 
 const contributorsFile = "./data/contributors.json";
 


### PR DESCRIPTION
I noticed that the contributors section were not being updated. 
Up on further investigation, it seems that the url `https://api.github.com/repos/Front-End-Coders-Mauritius/frontendmu.mu/contributors` found in the `update-contributors.js` script results in the below :point_down: 

![image](https://github.com/user-attachments/assets/ff86aea3-b99e-416f-8372-f63b02fe0c17)

I applied a fix by changing `frontendmu.mu` to `frontend.mu`. However, I was unable to test.

@MrSunshyne Could you please have a look? :pray: 

Fixes #158 