### PR TITLE
#164 Fixed pixelated carousel images on hero section

### DIFF
--- a/packages/frontendmu-nuxt/components/cards/CardAlbum.vue
+++ b/packages/frontendmu-nuxt/components/cards/CardAlbum.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="currentAlbum" class="grid grid-cols-3 items-center h-full">
     <NuxtImg v-for="photo in currentAlbum" :key="photo" :src="`${source}/${photo}`" alt="Album Photo" width="100"
-      height="auto" class="object-cover w-full h-full block" loading="lazy" />
+      height="160" class="object-cover w-full h-full block" loading="lazy" />
   </div>
 </template>
 


### PR DESCRIPTION
Fixes #164.

![image](https://github.com/user-attachments/assets/7aeeefe8-0242-4dd7-a5c5-f672b4c232aa)
